### PR TITLE
Always use barrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ pip install dramatiq-workflow
 Then, add the `dramatiq-workflow` middleware to your dramatiq broker:
 
 ```python
-from dramatiq.rate_limits.backends import RedisBackend
+from dramatiq.rate_limits.backends import RedisBackend  # or MemcachedBackend
 from dramatiq_workflow import WorkflowMiddleware
 
-backend = RedisBackend()
+backend = RedisBackend()  # or MemcachedBackend()
 broker.add_middleware(WorkflowMiddleware(backend))
 ```
 
@@ -152,6 +152,36 @@ workflow = Workflow(
 
 In this example, Task 2 will run roughly 1 second after Task 1 finishes, and
 Task 3 and will run 2 seconds after Task 2 finishes.
+
+### Barrier
+
+`dramatiq-workflow` uses a barrier mechanism to keep track of the current state
+of a workflow. For example, every time a task in a `Group` is completed, the
+barrier is decreased by one. When the barrier reaches zero, the next task in
+the outer `Chain` is scheduled to run.
+
+By default, `dramatiq-workflow` uses a custom `AtMostOnceBarrier` that ensures
+the barrier is never released more than once. When the barrier reaches zero, an
+additional key is set in the backend to prevent releasing the barrier again. In
+almost all cases, this is the desired behavior since releasing a barrier more
+than once could lead to duplicate tasks being scheduled - which would have
+severe compounding effects in a workflow with many `Group` tasks.
+
+However, there is a small chance that the barrier is never released. This can
+happen when the configured `rate_limiter_backend` loses its state or when the
+worker unexpectedly crashes before scheduling the next task in the workflow.
+
+To configure a different barrier implementation such as dramatiq's default
+`Barrier`, you can pass it to the `WorkflowMiddleware`:
+
+```python
+from dramatiq.rate_limits import Barrier
+from dramatiq.rate_limits.backends import RedisBackend
+from dramatiq_workflow import WorkflowMiddleware
+
+backend = RedisBackend()
+broker.add_middleware(WorkflowMiddleware(backend, barrier=Barrier))
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ from dramatiq.rate_limits.backends import RedisBackend
 from dramatiq_workflow import WorkflowMiddleware
 
 backend = RedisBackend()
-broker.add_middleware(WorkflowMiddleware(backend, barrier=Barrier))
+broker.add_middleware(WorkflowMiddleware(backend, barrier_type=Barrier))
 ```
 
 ## License

--- a/dramatiq_workflow/_base.py
+++ b/dramatiq_workflow/_base.py
@@ -180,10 +180,6 @@ class Workflow:
         return self.__middleware.barrier
 
     def __create_barrier(self, count: int):
-        if count == 1:
-            # No need to create a distributed barrier if there is only one task
-            return None
-
         completion_uuid = str(uuid4())
         completion_barrier = self.__barrier(self.__rate_limiter_backend, completion_uuid, ttl=CALLBACK_BARRIER_TTL)
         completion_barrier.create(count)

--- a/dramatiq_workflow/_base.py
+++ b/dramatiq_workflow/_base.py
@@ -182,12 +182,12 @@ class Workflow:
         return self.__middleware.rate_limiter_backend
 
     @property
-    def __barrier(self) -> type[dramatiq.rate_limits.Barrier]:
-        return self.__middleware.barrier
+    def __barrier_type(self) -> type[dramatiq.rate_limits.Barrier]:
+        return self.__middleware.barrier_type
 
     def __create_barrier(self, count: int) -> str:
         completion_uuid = str(uuid4())
-        completion_barrier = self.__barrier(self.__rate_limiter_backend, completion_uuid, ttl=CALLBACK_BARRIER_TTL)
+        completion_barrier = self.__barrier_type(self.__rate_limiter_backend, completion_uuid, ttl=CALLBACK_BARRIER_TTL)
         completion_barrier.create(count)
         logger.debug("Barrier created: %s (%d tasks)", completion_uuid, count)
         return completion_uuid

--- a/dramatiq_workflow/_base.py
+++ b/dramatiq_workflow/_base.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import typing
 from uuid import uuid4
 
 import dramatiq
@@ -176,7 +175,7 @@ class Workflow:
         return self.__middleware.rate_limiter_backend
 
     @property
-    def __barrier(self) -> typing.Type[dramatiq.rate_limits.Barrier]:
+    def __barrier(self) -> type[dramatiq.rate_limits.Barrier]:
         return self.__middleware.barrier
 
     def __create_barrier(self, count: int):

--- a/dramatiq_workflow/_middleware.py
+++ b/dramatiq_workflow/_middleware.py
@@ -1,5 +1,4 @@
 import logging
-import typing
 
 import dramatiq
 import dramatiq.rate_limits
@@ -16,7 +15,7 @@ class WorkflowMiddleware(dramatiq.Middleware):
     def __init__(
         self,
         rate_limiter_backend: dramatiq.rate_limits.RateLimiterBackend,
-        barrier: typing.Type[dramatiq.rate_limits.Barrier] = AtMostOnceBarrier,
+        barrier: type[dramatiq.rate_limits.Barrier] = AtMostOnceBarrier,
     ):
         self.rate_limiter_backend = rate_limiter_backend
         self.barrier = barrier

--- a/dramatiq_workflow/_middleware.py
+++ b/dramatiq_workflow/_middleware.py
@@ -16,10 +16,10 @@ class WorkflowMiddleware(dramatiq.Middleware):
     def __init__(
         self,
         rate_limiter_backend: dramatiq.rate_limits.RateLimiterBackend,
-        barrier: type[dramatiq.rate_limits.Barrier] = AtMostOnceBarrier,
+        barrier_type: type[dramatiq.rate_limits.Barrier] = AtMostOnceBarrier,
     ):
         self.rate_limiter_backend = rate_limiter_backend
-        self.barrier = barrier
+        self.barrier_type = barrier_type
 
     def after_process_boot(self, broker: dramatiq.Broker):
         broker.declare_actor(workflow_noop)
@@ -42,7 +42,7 @@ class WorkflowMiddleware(dramatiq.Middleware):
         while len(completion_callbacks) > 0:
             completion_id, remaining_workflow, propagate = completion_callbacks[-1]
             if completion_id is not None:
-                barrier = self.barrier(self.rate_limiter_backend, completion_id)
+                barrier = self.barrier_type(self.rate_limiter_backend, completion_id)
                 if not barrier.wait(block=False):
                     logger.debug("Barrier not completed: %s", completion_id)
                     break

--- a/dramatiq_workflow/_models.py
+++ b/dramatiq_workflow/_models.py
@@ -1,8 +1,6 @@
 import dramatiq
 import dramatiq.rate_limits
 
-from ._barrier import AtMostOnceBarrier
-
 
 class Chain:
     def __init__(self, *tasks: "WorkflowType"):
@@ -38,7 +36,6 @@ class WithDelay:
         return isinstance(other, WithDelay) and self.task == other.task and self.delay == other.delay
 
 
-Barrier = AtMostOnceBarrier
 Message = dramatiq.Message
 WorkflowType = Message | Chain | Group | WithDelay
 

--- a/dramatiq_workflow/tests/test_workflow.py
+++ b/dramatiq_workflow/tests/test_workflow.py
@@ -16,7 +16,7 @@ class WorkflowTests(unittest.TestCase):
             middleware=[
                 WorkflowMiddleware(
                     rate_limiter_backend=self.rate_limiter_backend,
-                    barrier=self.barrier,
+                    barrier_type=self.barrier,
                 )
             ]
         )

--- a/dramatiq_workflow/tests/test_workflow.py
+++ b/dramatiq_workflow/tests/test_workflow.py
@@ -80,7 +80,7 @@ class WorkflowTests(unittest.TestCase):
                 message_options={
                     "workflow_completion_callbacks": [
                         (
-                            None,
+                            mock.ANY,  # Accept any callback ID
                             {
                                 "__type__": "chain",
                                 "children": [
@@ -217,7 +217,7 @@ class WorkflowTests(unittest.TestCase):
                 message_options={
                     "workflow_completion_callbacks": [
                         (
-                            None,
+                            mock.ANY,  # Accept any callback ID
                             {
                                 "__type__": "chain",
                                 "children": [


### PR DESCRIPTION
Previously, we skipped creating a barrier when only one task was required to complete before continuing the workflow. However, this sometimes led to duplicate tasks when a task in a `Chain` was (incorrectly) retried after already having completed previously. To alleviate this, we now always create an `AtMostOnce` barrier, even if we only await the completion of a single task.

I also added a bit of documentation about the custom barrier implementation and a way to switch to the more lenient default `Barrier` implementation of dramatiq.