### PR TITLE
Skip no-op task if possible

### DIFF
--- a/dramatiq_workflow/_middleware.py
+++ b/dramatiq_workflow/_middleware.py
@@ -38,6 +38,11 @@ class WorkflowMiddleware(dramatiq.Middleware):
         if completion_callbacks is None:
             return
 
+        self._process_completion_callbacks(broker, completion_callbacks)
+
+    def _process_completion_callbacks(
+        self, broker: dramatiq.Broker, completion_callbacks: SerializedCompletionCallbacks
+    ):
         # Go through the completion callbacks backwards until we hit the first non-completed barrier
         while len(completion_callbacks) > 0:
             completion_id, remaining_workflow, propagate = completion_callbacks[-1]

--- a/dramatiq_workflow/tests/test_workflow.py
+++ b/dramatiq_workflow/tests/test_workflow.py
@@ -237,7 +237,7 @@ class WorkflowTests(unittest.TestCase):
         self.assertEqual(enqueued_message.options, {})
 
     def test_missing_middleware(self):
-        self.broker.middleware = []
+        self.broker = mock.MagicMock(middleware=[])
         workflow = Workflow(Chain(), broker=self.broker)
         with self.assertRaisesRegex(RuntimeError, "WorkflowMiddleware middleware not found"):
             workflow.run()


### PR DESCRIPTION
This PR optimizes the handling of empty `Chain` or `Group` workflows. Instead of scheduling a noop task and relying on the middleware to process completion callbacks, this change processes them directly within the `Workflow.run` method when there is no delay. This avoids an unnecessary round trip to the broker.

## Why do we even support empty `Chain`s and `Group`s?

Empty chains and groups are common when created programmatically:

```python
Chain(
  Group(*[do_a_bunch_of_work.message(id) for id in work_items]),
  finalize_work.message(),
)
```

In this example, `work_items` might be empty, in which case `finalize_work` should run immediately.