### PR TITLE
Expose walk_messages helper + document failure pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,70 @@ workflow = Workflow(
 ```
 
 In this example, Task 2 will run roughly 1 second after Task 1 finishes, and
-Task 3 and will run 2 seconds after Task 2 finishes.
+Tasks 3 and 4 will run 2 seconds after Task 2 finishes.
+
+### Handling Permanent Failures
+
+`dramatiq-workflow` does not provide built-in workflow-level failure handling.
+"What should happen when a workflow fails" is highly application-specific —
+fire-once vs. per-message, cancel pending steps or not, what to pass to the
+handler, how to interact with retries — and no single default is right for
+everyone.
+
+Instead, `dramatiq-workflow` exposes a helper, `walk_messages`, that makes it
+easy to build the semantics you want in a handful of lines of your own code.
+The pattern: stamp every message in the workflow with a failure-callback
+payload, then register a middleware that enqueues the payload when a message
+permanently fails.
+
+```python
+import dramatiq
+from dramatiq_workflow import Chain, Group, Workflow, walk_messages
+
+@dramatiq.actor
+def handle_failure(failed_message_id, failed_actor_name):
+    # Your alerting / cleanup / compensation logic.
+    # Should be idempotent — see caveats below.
+    ...
+
+# 1. Build the workflow tree and stamp every message with a failure payload.
+workflow_tree = Chain(
+    task1.message(),
+    Group(task2.message(), task3.message()),
+    task4.message(),
+)
+for msg in walk_messages(workflow_tree):
+    msg.options["on_failure"] = handle_failure.message(
+        msg.message_id, msg.actor_name
+    ).asdict()
+
+Workflow(workflow_tree).run()
+```
+
+```python
+# 2. Register a middleware that fires the stored callback on permanent failure.
+class WorkflowFailureMiddleware(dramatiq.Middleware):
+    def after_process_message(self, broker, message, *, result=None, exception=None):
+        if message.failed and "on_failure" in message.options:
+            broker.enqueue(dramatiq.Message(**message.options["on_failure"]))
+
+broker.add_middleware(WorkflowFailureMiddleware())
+```
+
+#### Caveats
+
+- **Fires per failing message.** A `Group` with three failing members enqueues
+  three failure callbacks. Make your handler idempotent.
+- **Requires dramatiq's `Retries` middleware** (active by default) to set
+  `message.failed=True` once retries are exhausted.
+- **The stamped payload lives in `message.options`** and must be
+  JSON-serializable by your broker's encoder.
+- **Nested workflows** dispatched from inside an actor are not stamped
+  automatically — call `walk_messages` on those trees too.
+- **`workflow_noop`** (auto-inserted by the library for empty `Chain` or
+  `Group`) is never stamped, but it does nothing and cannot meaningfully fail.
+- **The failure-handler message itself** should not carry a completion-callback
+  option — enqueue it fresh as shown, don't clone a workflow message.
 
 ### Large Workflows
 

--- a/dramatiq_workflow/__init__.py
+++ b/dramatiq_workflow/__init__.py
@@ -9,6 +9,7 @@ from ._models import (
     SerializedCompletionCallbacks,
     WithDelay,
     WorkflowType,
+    walk_messages,
 )
 from ._storage import CallbackStorage, DedupWorkflowCallbackStorage, InlineCallbackStorage
 
@@ -26,4 +27,5 @@ __all__ = [
     "Workflow",
     "WorkflowMiddleware",
     "WorkflowType",
+    "walk_messages",
 ]

--- a/dramatiq_workflow/_models.py
+++ b/dramatiq_workflow/_models.py
@@ -44,3 +44,21 @@ WorkflowType = Message | Chain | Group | WithDelay
 LazyWorkflow = typing.Callable[[], dict]
 SerializedCompletionCallback = tuple[str, dict | LazyWorkflow | None, bool]
 SerializedCompletionCallbacks = list[SerializedCompletionCallback]
+
+
+def walk_messages(workflow: WorkflowType) -> typing.Iterator[Message]:
+    """Yield every Message in a workflow tree, in definition order.
+
+    Useful for stamping custom options on every message before calling
+    ``Workflow(...).run()`` — see the "Handling Permanent Failures"
+    section of the README for the failure-callback pattern.
+    """
+    if isinstance(workflow, Message):
+        yield workflow
+    elif isinstance(workflow, (Chain, Group)):
+        for task in workflow.tasks:
+            yield from walk_messages(task)
+    elif isinstance(workflow, WithDelay):
+        yield from walk_messages(workflow.task)
+    else:
+        raise TypeError(f"Unsupported workflow type: {type(workflow)}")

--- a/dramatiq_workflow/tests/test_walk_messages.py
+++ b/dramatiq_workflow/tests/test_walk_messages.py
@@ -1,0 +1,78 @@
+import unittest
+
+import dramatiq
+
+from .. import Chain, Group, WithDelay, walk_messages
+
+
+def _make_message(message_id: int) -> dramatiq.Message:
+    return dramatiq.Message(
+        message_id=str(message_id),
+        message_timestamp=0,
+        queue_name="default",
+        actor_name="task",
+        args=(),
+        kwargs={},
+        options={},
+    )
+
+
+class WalkMessagesTests(unittest.TestCase):
+    def test_bare_message_yields_itself(self):
+        msg = _make_message(1)
+        self.assertEqual(list(walk_messages(msg)), [msg])
+
+    def test_bare_message_yields_same_identity(self):
+        msg = _make_message(1)
+        [yielded] = list(walk_messages(msg))
+        self.assertIs(yielded, msg)
+
+    def test_chain_yields_in_order(self):
+        a, b, c = _make_message(1), _make_message(2), _make_message(3)
+        self.assertEqual(list(walk_messages(Chain(a, b, c))), [a, b, c])
+
+    def test_group_yields_in_order(self):
+        a, b = _make_message(1), _make_message(2)
+        self.assertEqual(list(walk_messages(Group(a, b))), [a, b])
+
+    def test_nested_chain_group_flattens_in_definition_order(self):
+        a, b, c, d = (_make_message(i) for i in range(1, 5))
+        workflow = Chain(a, Group(b, c), d)
+        self.assertEqual(list(walk_messages(workflow)), [a, b, c, d])
+
+    def test_deeply_nested(self):
+        a, b, c, d = (_make_message(i) for i in range(1, 5))
+        workflow = Chain(a, Group(Chain(b, c)), d)
+        self.assertEqual(list(walk_messages(workflow)), [a, b, c, d])
+
+    def test_with_delay_at_root_is_transparent(self):
+        a, b = _make_message(1), _make_message(2)
+        self.assertEqual(list(walk_messages(WithDelay(Chain(a, b), delay=1000))), [a, b])
+
+    def test_with_delay_inside_chain_is_transparent(self):
+        a, b = _make_message(1), _make_message(2)
+        self.assertEqual(list(walk_messages(Chain(WithDelay(a, delay=100), b))), [a, b])
+
+    def test_with_delay_wrapping_single_message(self):
+        a = _make_message(1)
+        self.assertEqual(list(walk_messages(WithDelay(a, delay=100))), [a])
+
+    def test_empty_chain_yields_nothing(self):
+        self.assertEqual(list(walk_messages(Chain())), [])
+
+    def test_empty_group_yields_nothing(self):
+        self.assertEqual(list(walk_messages(Group())), [])
+
+    def test_unsupported_type_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            list(walk_messages("not a workflow"))  # type: ignore[arg-type]
+
+    def test_is_a_generator(self):
+        # Make sure it's lazy — mutations during iteration should affect yields
+        a, b = _make_message(1), _make_message(2)
+        gen = walk_messages(Chain(a, b))
+        self.assertIs(next(gen), a)
+        a.options["stamped"] = True
+        self.assertIs(next(gen), b)
+        # Confirm the mutation survived — this is what the README pattern relies on
+        self.assertEqual(a.options.get("stamped"), True)


### PR DESCRIPTION
## Summary

- Expose `walk_messages(workflow)` — a public generator yielding every `Message` in a workflow tree in definition order. Makes it ergonomic to stamp custom options (e.g. failure-callback payloads) on every message before running the workflow.
- New README section **"Handling Permanent Failures"** documenting the external pattern: stamp messages with `walk_messages`, then register a small middleware that fires the stored callback on `message.failed`. The library deliberately takes no opinion on failure semantics (fire-once vs. per-message, cancellation, handler arguments, etc.).
- Minor: fix a pre-existing typo in the `WithDelay` example ("Task 3 and will run" → "Tasks 3 and 4 will run").

Pure addition — no changes to `Workflow`, `WorkflowMiddleware`, serialization, storage, or the serialized message shape.

## Test plan

- [x] `pytest dramatiq_workflow` — 38/38 locally (25 existing + 13 new tests covering bare / Chain / Group / nested / `WithDelay` / empty / unknown-type / lazy-generator cases)
- [x] `pre-commit run --all-files` — pyupgrade, ruff, ruff-format, check-vcs-permalinks all pass
- [x] CI matrix (Python 3.10–3.14 × Dramatiq 1.x / 2.x) green
- [x] README snippets render correctly on GitHub

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `walk_messages` helper and document permanent failure handling pattern
> - Adds `walk_messages` generator in [_models.py](https://github.com/Outset-AI/dramatiq-workflow/pull/14/files#diff-0d2655a6d0cae84f247b4e7db4ff6a6cbb7d9a360295b6e58544e41448eb480b) that yields every `Message` in a workflow tree in definition order, recursing into `Chain`, `Group`, and `WithDelay`; raises `TypeError` for unsupported types.
> - Exports `walk_messages` from the package root so it can be imported as `from dramatiq_workflow import walk_messages`.
> - Adds a 'Handling Permanent Failures' section to the README documenting how to use `walk_messages` to stamp messages with an `on_failure` payload and a middleware to enqueue the failure handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05737a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->